### PR TITLE
fix(sessions,#8) - fix mission name containing commas breaking the session mission list

### DIFF
--- a/handlers/editSession.py
+++ b/handlers/editSession.py
@@ -33,7 +33,7 @@ class EditSessionHandler(Handler):
         newMissions = []
 
         if existingMissionNames['missionNames'] is not None:
-            existingMissionNames = existingMissionNames['missionNames'].split(",")
+            existingMissionNames = json.loads(existingMissionNames['missionNames'])
             for mission in missions:
                 if mission in existingMissionNames:
                     existingMissionNames.remove(mission)
@@ -52,7 +52,12 @@ class EditSessionHandler(Handler):
 
     def toParams(self, editSessionJson, sessionId):
         params = []
-        params.append(",".join(editSessionJson['missionNames']))
+
+        mission_names = editSessionJson['missionNames']
+        if mission_names is None:
+            mission_names = []
+
+        params.append(json.dumps(mission_names))
         params.append(editSessionJson['host'])
         params.append(editSessionJson['name'])
         params.append(editSessionJson['players'])

--- a/handlers/session.py
+++ b/handlers/session.py
@@ -18,7 +18,7 @@ class SessionsHandler(Handler):
         user = environ['user']
         sessionDtos = [dict(x) for x in sessions]
         for x in sessionDtos:
-            x['missionNamesList'] = x['missionNames'].split(",")
+            x['missionNamesList'] = json.loads(x['missionNames'])
             if user is not None:
                 if user.permissionLevel >= 2:
                     x['allowedToEdit'] = True


### PR DESCRIPTION
Fixes #8 

Fixes the issue for new sessions created and also retroactively goes back and corrects old session lists (with a little bit of guesswork / assumptions)

99% sure this is working but want to test a bit more first hence the draft