### PR TITLE
[#21] Added Framework search.

### DIFF
--- a/handleDbStart.py
+++ b/handleDbStart.py
@@ -13,6 +13,8 @@ def initDb():
     db_migrate_ensure_users_sessionkeys(c)
     db_migrate_add_missions_cdlcflag(c)
     db_migrate_reencode_session_missionnames_as_json(c)
+    db_migrate_set_null_framework_to_unknown(c)
+    db_migrate_framework_prefix_old_f3(c)
 
     # Save (commit) the changes
     c.connection.commit()
@@ -20,6 +22,24 @@ def initDb():
     # We can also close the connection if we are done with it.
     # Just be sure any changes have been committed or they will be lost.
     c.connection.close()
+
+
+def db_migrate_framework_prefix_old_f3(c):
+    # Some older missions has both 'x.x.x' and 'F3 x.x.x' entries in database. Clean-up by adding prefix to former
+    c.execute('''update missions set framework = 'F3 '||framework where framework in (
+        '3.1.x or older',
+        '3.2.0',
+        '3.2.1',
+        '3.2.2',
+        '3.3.0',
+        '3.3.x or older',
+        '3.4.0',
+        '3.4.1'
+    )''')
+
+
+def db_migrate_set_null_framework_to_unknown(c):
+    c.execute("update missions set framework = 'Unknown' where framework is NULL")
 
 
 def db_migrate_reencode_session_missionnames_as_json(c):

--- a/handlers/missions.py
+++ b/handlers/missions.py
@@ -146,6 +146,8 @@ class MissionsHandler(Handler):
         if "missionTypes[]" in params:
             missionTypeString = ["'{0}'".format(w) for w in params['missionTypes[]']]
             query.append(str.format("missionType in({})", ",".join(missionTypeString)))
+        if "frameworks[]" in params:
+            query.append(str.format("framework in({})", ",".join([f"'{f}'" for f in params['frameworks[]']])))
         if "playerMax" in params:
             query.append("missionPlayers  <= ? ")
             p.append(params['playerMax'][0])

--- a/static/index.html
+++ b/static/index.html
@@ -78,6 +78,12 @@
                     </option>
                 </select>
 
+                <select id="searchFramework" name="searchFramework">
+                    <option>
+                        All Frameworks
+                    </option>
+                </select>
+
                 <select id="status" name="status">
                     <option>
                         All Statuses
@@ -255,6 +261,7 @@
 <script>
         GetIslandsList("#islandSelected");
         GenerateMissionTypesCheckbox("#missionTypes");
+        PopulateFrameworkCategoryList("#searchFramework");
         GetStatuses("#status");
 </script>
 <script src="js/popup.js" type="text/javascript"></script>

--- a/static/js/missions.js
+++ b/static/js/missions.js
@@ -17,11 +17,11 @@ function LoadData() {
     var mapVal = $("#islandSelected").val();
     var authorVal = $("#authorSelected").val();
     var searchVal = $("#searchText").val();
+    var frameworkVal = $("#searchFramework").val();
     var params = {};
     params["map"] = mapVal;
     params["status"] = $("#status").val();
     params["author"] = authorVal;
-
 
     var checkboxes = $("#missionTypes").find(':checkbox');
     var typeString = [];
@@ -46,6 +46,10 @@ function LoadData() {
     params["playerMax"] = Number($("#slotsMax").val());
     params["playerMin"] = Number($("#slotsMin").val());
     params["cdlcFilter"] = $("#cdlcFilterSelected").val();
+
+    if(frameworkVal !== "All Frameworks") {
+        params["frameworks"] = frameworks[frameworkVal].versions;
+    }
 
     jQuery.get("missions", params, function (data, status, jqXHR)
     {

--- a/static/js/types.js
+++ b/static/js/types.js
@@ -24,7 +24,44 @@ var islands = [
     "Weferlingen (Winter)", // CDLC - GM
     "Virtual Reality"       // Vanilla
 ];
-
+var frameworks = {
+    "Modern FA3 (>= 3.5)": {
+        "uiPriority": 0, // order to appear in dropdown, 0 being closet to top
+        "versions": [    // order in dropdowns, so newer at top makes sense. Needs to be exhaustive for search to work
+            //"FA3 3.5.7",
+            "FA3 3.5.6",
+            "FA3 3.5.5",
+            "FA3 3.5.4",
+            "FA3 3.5.3",
+            "FA3 3.5.2",
+            "F3 3.5.1",
+            "F3 3.5.0",
+            "F3 3.5"
+        ]
+    },
+    "Legacy F3 (3.4.x)": {
+        "uiPriority": 1,
+        "versions": [
+            "F3 3.4.1",
+            "F3 3.4.0",
+        ]
+    },
+    "Ancient F3 (<= 3.3.0)": {
+        "uiPriority": 2,
+        "versions": [
+            "F3 3.3.x or older", // Values from database (after db_migrate_framework_prefix_old_f3 cleanup)
+            "F3 3.3.0",
+            "F3 3.2.2",
+            "F3 3.2.1",
+            "F3 3.2.0",
+            "F3 3.1.x or older"
+        ]
+    },
+    "Unknown framework": {
+        "uiPriority": 3,
+        "versions": ["Unknown"]
+    }
+}
 
 function GetIslandsList(parent) {
     "use strict";
@@ -36,6 +73,7 @@ function GetIslandsList(parent) {
         }));
     });
 }
+
 function GetMissionTypesList(parent) {
     "use strict";
     $.each(missionTypes, function (key, value) {
@@ -54,7 +92,8 @@ function GetStatuses(parent) {
             text: value
         }));
     });
-} 
+}
+
 function GenerateMissionTypesCheckbox(parent) {
     "use strict";
     $.each(missionTypes, function (key, value) {
@@ -64,3 +103,31 @@ function GenerateMissionTypesCheckbox(parent) {
     });
 } 
 
+function PopulateFrameworkCategoryList(parent) {
+    "use strict";
+
+    let orderedCategories = Object.keys(frameworks)
+        .sort((a,b) => {return frameworks[a].uiPriority - frameworks[b].uiPriority} )
+
+    $.each(orderedCategories, function (key, value) {
+        $(parent).append($("<option/>", {
+            value: value,
+            text: value
+        }));
+    });
+}
+
+function PopulateFrameworkVersionList(parent) {
+    "use strict";
+
+    let orderedVersions = Object.keys(frameworks)
+        .sort((a,b) => {return frameworks[a].uiPriority - frameworks[b].uiPriority} )
+        .flatMap(name => frameworks[name].versions)
+
+    $.each(orderedVersions, function (key, value) {
+        $(parent).append($("<option/>", {
+            value: value,
+            text: value
+        }));
+    });
+}

--- a/static/missionForm.html
+++ b/static/missionForm.html
@@ -96,38 +96,7 @@
                     <br>
                     <label for="framework">Framework</label>
                     <br>
-                    <select id="framework" name="framework">
-					    <option>
-                            FA3 3.5.6
-                        </option>
-						<option>
-                            FA3 3.5.5
-                        </option>
-                        <option>
-                            FA3 3.5.4
-                        </option>
-                        <option>
-                            FA3 3.5.3
-                        </option>
-                        <option>
-                            FA3 3.5.2
-                        </option>
-                        <option>
-                            F3 3.5.1
-                        </option>
-                        <option>
-                            F3 3.5.0
-                        </option>
-                        <option>
-                            F3 3.4.1
-                        </option>
-                        <option>
-                            F3 3.4.0
-                        </option>
-                        <option>
-                            F3 3.3.x or older
-                        </option>
-                    </select>
+                    <select id="framework" name="framework"></select>
                     <br>
                 </div>
 
@@ -170,6 +139,7 @@
 <script>
     GetIslandsList("#missionIsland");
     GetMissionTypesList("#missionType")
+    PopulateFrameworkVersionList("#framework")
 </script>
 <script src="js/popup.js" type="text/javascript"></script>
 <script src="js/user.js" type="text/javascript"></script>


### PR DESCRIPTION
Resolves #21.

Adds a Framework dropdown to the search panel which searches mission by framework. Framework versions are (statically) grouped into categories for a better UX. Part of this was extracting the list of frameworks, so the create mission dropdown now uses the same list (without the categories).

This also includes a general cleanup of the framework versions in the database:
* Some old missions had no framework defined (NULL). These are now set to 'Unknown'
* Some old missions used both 'x.x.x' and 'F3 x.x.x' for framework. This is now standardised on 'F3 x.x.x'.

## Screenshots
![famdb-search-newdropdown](https://user-images.githubusercontent.com/733683/193415366-bfd68436-60c1-402c-9a62-ab975cddbb53.png)
_New dropdown on search panel_

![famdb-search-newdropdownexpanded](https://user-images.githubusercontent.com/733683/193415370-d0cd7ba7-58e8-42b9-ad06-4315f5cf2c61.png)
_New dropdown on search panel expanded_

![famdb-create-newdropdownexpanded](https://user-images.githubusercontent.com/733683/193415372-bd733053-1a68-4066-a65b-30972e77514a.png)
_Dropdown in create missions expanded to show new values_


@NikkoJT @Aqarius90 Review of "look&feel" of screenshots would be appreciated (code review also welcome but not expected)