### PR TITLE
[#1] Fix id reuse issues with autoincrement

### DIFF
--- a/handleDbStart.py
+++ b/handleDbStart.py
@@ -20,6 +20,8 @@ def initDb():
     # Save (commit) the changes
     c.connection.commit()
 
+    db_migrate_exclusive_add_autoincrement_to_int_pks(c)
+
     db_populate_valid_tags(c)
 
     # We can also close the connection if we are done with it.
@@ -90,6 +92,57 @@ def db_populate_valid_tags(c):
     c.execute('''begin exclusive transaction''')
     c.execute('''delete from valid_tags''')
     c.executemany('''insert into valid_tags (tag) values (?)''', [(tag,) for tag in valid_tags])
+    c.execute('''commit transaction''')
+
+
+def db_migrate_exclusive_add_autoincrement_to_int_pks(c):
+    c.execute('''begin exclusive transaction''')
+
+    if c.execute("select count(*) from sqlite_master where type = 'table' and name = 'users' and sql like '%autoincrement%'").fetchone()[0] == 0:
+        print('Adding autoincrement to primary key of users table')
+        c.execute('''CREATE TABLE users_new
+                 (id integer primary key autoincrement, login text, email text, password text, createDate text, lastLogin text, permissionLevel integer, sessionKey text, resetPwLink text, discordId text)''')
+        c.execute('''INSERT INTO users_new(id, login, email, password, createDate, lastLogin, permissionLevel, sessionKey, resetPwLink, discordId)
+                    select id, login, email, password, createDate, lastLogin, permissionLevel, sessionKey, resetPwLink, discordId from users''')
+        c.execute('''DROP TABLE users''')
+        c.execute('''ALTER TABLE users_new RENAME TO users''')
+
+    if c.execute("select count(*) from sqlite_master where type = 'table' and name = 'sessions' and sql like '%autoincrement%'").fetchone()[0] == 0:
+        print('Adding autoincrement to primary key of sessions table')
+        c.execute('''CREATE TABLE sessions_new
+                 (id integer primary key autoincrement, missionNames text, date text, host text, name text, players integer)''')
+        c.execute('''INSERT INTO sessions_new(id, missionNames, date, host, name, players)
+                    select id, missionNames, date, host, name, players from sessions''')
+        c.execute('''DROP TABLE sessions''')
+        c.execute('''ALTER TABLE sessions_new RENAME TO sessions''')
+
+    if c.execute("select count(*) from sqlite_master where type = 'table' and name = 'versions' and sql like '%autoincrement%'").fetchone()[0] == 0:
+        print('Adding autoincrement to primary key of versions table')
+        c.execute('''CREATE TABLE versions_new
+                 (id integer primary key autoincrement, missionId INTEGER, existsOnMM INTEGER DEFAULT 1, existsOnMain INTEGER DEFAULT 0, name TEXT, createDate TEXT, toBeDeletedMM INTEGER DEFAULT 0, toBeDeletedMain INTEGER DEFAULT 0, requestedTransfer INTEGER DEFAULT 0, requestedTesting integer default 0)''')
+        c.execute('''INSERT INTO versions_new(id, missionId, existsOnMM, existsOnMain, name, createDate, toBeDeletedMM, toBeDeletedMain, requestedTransfer, requestedTesting)
+                    select id, missionId, existsOnMM, existsOnMain, name, createDate, toBeDeletedMM, toBeDeletedMain, requestedTransfer, requestedTesting from versions''')
+        c.execute('''DROP TABLE versions''')
+        c.execute('''ALTER TABLE versions_new RENAME TO versions''')
+
+    if c.execute("select count(*) from sqlite_master where type = 'table' and name = 'missions' and sql like '%autoincrement%'").fetchone()[0] == 0:
+        print('Adding autoincrement to primary key of missions table')
+        c.execute('''CREATE TABLE missions_new
+                 (id integer primary key autoincrement, missionName TEXT, lastPlayed TEXT, missionAuthor TEXT, missionModified TEXT, framework TEXT, missionPlayers INT, missionType TEXT, missionMap TEXT, playedCounter INT DEFAULT 0, missionDesc TEXT, missionNotes TEXT, status VARCHAR DEFAULT 'WIP', isCDLCMission integer default 0)''')
+        c.execute('''INSERT INTO missions_new(id, missionName, lastPlayed, missionAuthor, missionModified, framework, missionPlayers, missionType, missionMap, playedCounter, missionDesc, missionNotes, status, isCDLCMission)
+                    select id, missionName, lastPlayed, missionAuthor, missionModified, framework, missionPlayers, missionType, missionMap, playedCounter, missionDesc, missionNotes, status, isCDLCMission from missions''')
+        c.execute('''DROP TABLE missions''')
+        c.execute('''ALTER TABLE missions_new RENAME TO missions''')
+
+    if c.execute("select count(*) from sqlite_master where type = 'table' and name = 'comments' and sql like '%autoincrement%'").fetchone()[0] == 0:
+        print('Adding autoincrement to primary key of comments table')
+        c.execute('''CREATE TABLE comments_new
+                     (id integer primary key autoincrement, contents text, user text, createDate text, missionId integer, versionId integer)''')
+        c.execute('''INSERT INTO comments_new(id, contents, user, createDate, missionId, versionId)
+                    select id, contents, user, createDate, missionId, versionId from comments''')
+        c.execute('''DROP TABLE comments''')
+        c.execute('''ALTER TABLE comments_new RENAME TO comments''')
+
     c.execute('''commit transaction''')
 
 


### PR DESCRIPTION
Resolves #1

Fixes the "comment out of order issue", which ended up being an id reuse issue with versions, by adding autoincrement to the versions table. Also added to all other tables to prevent future issues.

Unfortunately this fix doesn't work retroactively but at least it won't reoccur