### PR TITLE
[#33] - add PBO validation to file upload, and generally improve the upload process

### DIFF
--- a/static/js/missions.js
+++ b/static/js/missions.js
@@ -187,6 +187,9 @@ function submitComment(button) {
 }
 
 function uploadFile(submitButton){
+    // Reset the error message when a new upload starts
+    $(submitButton).siblings(".uploadErrorMessage").text("");
+
     var button = $(submitButton).siblings("input")[0];
     var files = button.files;
     for(var i=0; i<files.length; i++){
@@ -201,9 +204,8 @@ function uploadFile(submitButton){
                 // Every thing ok, file uploaded
                 window.location.href = "index.html?missionId=" + missionId;
             }else {
-                if(xhr.status == 500) {
-                    var span = $($(submitButton).siblings(".uploadErrorMessage")[0])[0];
-                    span.innerText = xhr.responseText;
+                if(xhr.status >= 400) {
+                    $(submitButton).siblings(".uploadErrorMessage").text("Upload failed! " + xhr.responseText);
                 }
             }
         };
@@ -223,7 +225,10 @@ function updateFileLabel(uploadSystem) {
     for(var i=0; i < files.length; i++) {
         text += files[i].name + ",";
     }
-    div.innerHTML = (text)
+    div.innerHTML = (text);
+
+    // Reset the error message when a new file is selected
+    $(uploadSystem).siblings(".uploadErrorMessage").text("");
 }
 function openDeletePopup(button) {
     window.delMissionId = $(button).data("missionid");

--- a/static/missionTemplate.js
+++ b/static/missionTemplate.js
@@ -67,9 +67,10 @@ $.templates("missionTmpl", `<tr class='row' id={{:id}}>
                 <input id='fileUpload{{:id}}' onchange='updateFileLabel(this)' data-missionId='{{:id}}'
                        style='display:none'
                        type='file'
+                       accept=".pbo"
                        multiple='multiple'/>
                 <a onclick='uploadFile(this)'>Submit</a>
-                <span class='uploadErrorMessage'></span>
+                <span style='font-weight:bold; color:red;' class='uploadErrorMessage'></span>
             </li>
         {{/if}}
             {{if hasOwnProperty('versions')}}


### PR DESCRIPTION
Uploaded files are now checked to see if they are valid PBO files. Should avoid uploads that end too soon or other file corruption getting onto the server. The upload process now lets `cgi` handle the details of form parsing and file upload instead of the "interesting" previous code. Finally, some UI improvements: the file dialog only shows .pbo files and any error message from the upload is now bold and red to make it standout when an error occurs.

Resolves #33 